### PR TITLE
fix: remove target from TransitionRegression

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dymiumCore
 Type: Package
 Title: The core functions of a Dynamic Microsimulation framework for Integrated Urban Models
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(
     person("Amarin", "Siripanich", email = "amarin@dymium.org", role = c("aut", "cre")),
     person("Taha", "Rashidi", role = c("aut")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dymiumCore 0.1.1
+
+- Removed the `target` argument from [TransitionRegression] as alignment is only applicable for classficaition model.
+
 # dymiumCore 0.1.0
 
 This version contains all the basic building blocks for dynamic microsimulation.

--- a/R/Transition.R
+++ b/R/Transition.R
@@ -412,9 +412,9 @@ monte_carlo_sim <- function(prediction, target) {
 #' trans(Ind, model_glm)
 trans <- function(entity, model, target = NULL, targeted_agents = NULL, update_attr = NULL) {
   if (is_regression(model)) {
-    trans <- TransitionRegression$new(entity, model, target, targeted_agents)
+    trans <- TransitionRegression$new(x = entity, model = model, targeted_agents = targeted_agents)
   } else {
-    trans <- TransitionClassification$new(entity, model, target, targeted_agents)
+    trans <- TransitionClassification$new(x = entity, model = model, target = target, targeted_agents = targeted_agents)
   }
   if (!is.null(update_attr)) {
     trans$update_agents(update_attr)

--- a/R/TransitionClassification.R
+++ b/R/TransitionClassification.R
@@ -23,7 +23,7 @@
 #' TransitionClassification$new(x, model, target = NULL, targeted_agents = NULL)
 #' ```
 #'
-#' * `x` :: [R6:R6Class]\cr
+#' * `x` :: [R6::R6Class]\cr
 #'   An [Entity] object or its inheritances.
 #'
 #' * `model` :: `any object` in [SupportedTransitionModels]\cr

--- a/man/TransitionClassification.Rd
+++ b/man/TransitionClassification.Rd
@@ -44,7 +44,7 @@ Create a \link{TransitionClassification} object.
 \preformatted{TransitionClassification$new(x, model, target = NULL, targeted_agents = NULL)
 }
 \itemize{
-\item \code{x} :: \link{R6:R6Class}\cr
+\item \code{x} :: \link[R6:R6Class]{R6::R6Class}\cr
 An \link{Entity} object or its inheritances.
 \item \code{model} :: \verb{any object} in \link{SupportedTransitionModels}\cr
 A model object to be used to simulate transition.


### PR DESCRIPTION
target alignment is not applicable for regresison model
